### PR TITLE
Improve command to find instance namespace

### DIFF
--- a/docs/modules/ROOT/pages/vshn-managed/how-tos/logging.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/how-tos/logging.adoc
@@ -9,13 +9,16 @@ The access to those namespaces is deliberately limited, for more information see
 
 It is possible to list and view the logs of all pods in those namespaces.
 
-.Get the instance namespaces
+.Get the instance namespaces for your services
 [source,bash]
 ----
-oc describe vshnredis | grep "Instance Namespace"
+kubectl get vshnredis,vshnpostgresql -o custom-columns="KIND":.kind,"NAME":.metadata.name,"INSTANCE NAMESPACE":.status.instanceNamespace
+KIND             NAME         INSTANCE NAMESPACE
+VSHNRedis        app1-prod    vshn-redis-app1-prod-rt4w5
+VSHNPostgreSQL   buzz         vshn-postgresql-buzz-qvgrd
 ----
 
-Once the instance namespace is identified, it's possible to list the pods within it.
+Once the instance namespace is identified, it's possible to list the pods within it, in this case all pods of our redis instance.
 
 .List pods in the namespace
 [source,bash]
@@ -26,6 +29,7 @@ redis-master-0   1/1     Running   0          105m
 ----
 
 After the correct pod has been found the logs can be shown as usual via the CLI.
+For our example we look at the logs of the redis pod.
 
 .Print redis logs
 [source,bash]

--- a/docs/modules/ROOT/pages/vshn-managed/how-tos/logging.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/how-tos/logging.adoc
@@ -12,7 +12,7 @@ It is possible to list and view the logs of all pods in those namespaces.
 .Get the instance namespaces
 [source,bash]
 ----
-kubectl  get vshnredis claim -ojsonpath="{.status.instanceNamespace}"
+oc describe vshnredis | grep "Instance Namespace"
 ----
 
 Once the instance namespace is identified, it's possible to list the pods within it.


### PR DESCRIPTION
The previous command does not work for me:
$ kubectl  get vshnredis claim -ojsonpath="{.status.instanceNamespace}" Error from server (NotFound): vshnredis.vshn.appcat.vshn.io "claim" not found

instead, this gives me the namespace:
$ oc describe vshnredis | grep "Instance Namespace"
  Instance Namespace:     vshn-redis-my-redis-m5rvj