### PR TITLE
Add postgres sla docs

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -19,6 +19,7 @@
 ** xref:vshn-managed/postgresql/restore.adoc[Restore]
 ** xref:vshn-managed/postgresql/maintenance.adoc[]
 ** xref:vshn-managed/postgresql/plans.adoc[]
+** xref:vshn-managed/postgresql/sla.adoc[]
 ** xref:vshn-managed/postgresql/deletion-protection.adoc[]
 ** xref:vshn-managed/postgresql/encrypted-pvc.adoc[]
 ** xref:vshn-managed/postgresql/alerting.adoc[]

--- a/docs/modules/ROOT/pages/vshn-managed/postgresql/sla.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/postgresql/sla.adoc
@@ -1,0 +1,32 @@
+= Service Level Agreement
+
+[IMPORTANT]
+====
+The Service Level Agreement can be chosen during a PostgreSQL instance request.
+It can be changed later on. The price together with the provided service will be updated accordingly. The change takes effect on the 1st of the next month.
+For more information regarding price check https://products.vshn.ch/appcat/postgresql.html#_pricing[products.vshn.ch]
+====
+
+== Configuration
+
+The Service Level is enabled by default as `besteffort`. To upgrade the service to `guaranteed` use the following configuration:
+
+.Example of a PostgreSQL instance with `besteffort` service level. Update the namespace!
+[source,yaml]
+----
+apiVersion: vshn.appcat.vshn.io/v1
+kind: VSHNPostgreSQL
+metadata:
+  name: pgsql-app1-guaranteed
+  namespace: <your-namespace>
+spec:
+  parameters:
+    service:
+      serviceLevel: guaranteed <1>
+      majorVersion: "15"
+      pgSettings:
+        timezone: Europe/Zurich
+  writeConnectionSecretToRef:
+    name: postgres-creds
+----
+<1> Choose between `besteffort` or `guaranteed` service level.


### PR DESCRIPTION
This PR adds end user docs on how to choose SLA for VSHN PostgreSQL instances.