### PR TITLE
Fix Redis URL docs

### DIFF
--- a/docs/modules/ROOT/pages/references/secrets.adoc
+++ b/docs/modules/ROOT/pages/references/secrets.adoc
@@ -86,10 +86,10 @@ kind: Secret
 metadata:
   name: redis-creds
 stringData:
-  REDIS_HOST: 127.0.0.1 <1>
+  REDIS_HOST: my-redis-example.my-cloud.com <1>
   REDIS_PASSWORD: my-secret <2>
   REDIS_PORT: 21700 <3>
-  REDIS_URL: rediss://default:my-secret@127.0.0.1:21700 <4>
+  REDIS_URL: rediss://default:my-secret@my-redis-example.my-cloud.com:21700 <4>
   REDIS_USERNAME: default <5>
   ca.crt: base64encoded(data) <6>
   tls.crt: base64encoded(data) <7>


### PR DESCRIPTION
This PR fixes the docs for the Exoscale Redis URL exposed via secret