### PR TITLE
Add Minio end-user docs

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -67,8 +67,8 @@
 * xref:object-storage/delete.adoc[Deletion]
 * xref:object-storage/references.adoc[Reference Documentation]
 
-.Minio
-* xref:vshn-managed/minio.adoc[On APPPUiO Managed]
+.MinIO
+* xref:vshn-managed/minio.adoc[On On-Premise]
 
 .Advanced
 * xref:references/permissions.adoc[Namespace Permissions]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -67,6 +67,9 @@
 * xref:object-storage/delete.adoc[Deletion]
 * xref:object-storage/references.adoc[Reference Documentation]
 
+.Minio
+* xref:vshn-managed/minio.adoc[On APPPUiO Managed]
+
 .Advanced
 * xref:references/permissions.adoc[Namespace Permissions]
 * xref:references/argocd.adoc[Usage with ArgoCD]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -68,7 +68,7 @@
 * xref:object-storage/references.adoc[Reference Documentation]
 
 .MinIO
-* xref:vshn-managed/minio.adoc[On On-Premise]
+* xref:vshn-managed/minio.adoc[On Private Cloud]
 
 .Advanced
 * xref:references/permissions.adoc[Namespace Permissions]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -11,7 +11,7 @@ To get started, click xref:getting-started.adoc[here].
 |Service
 |Exoscale
 |cloudscale.ch
-|On-Premise
+|Private Cloud
 
 |PostgreSQL
 |xref:exoscale-dbaas/postgresql/create.adoc[Create] and xref:exoscale-dbaas/postgresql/usage.adoc[use]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -6,35 +6,47 @@ TIP: To get more information about the product, please consult our https://produ
 
 To get started, click xref:getting-started.adoc[here].
 
-[cols="1s,1,1", options="header", stripes="even"]
+[cols="1s,1,1,1", options="header", stripes="even"]
 |===
 |Service
 |Exoscale
 |cloudscale.ch
+|On-Premise
 
 |PostgreSQL
 |xref:exoscale-dbaas/postgresql/create.adoc[Create] and xref:exoscale-dbaas/postgresql/usage.adoc[use]
+|xref:vshn-managed/postgresql/create.adoc[Create] and xref:vshn-managed/postgresql/usage.adoc[use]
 |xref:vshn-managed/postgresql/create.adoc[Create] and xref:vshn-managed/postgresql/usage.adoc[use]
 
 |MySQL
 |xref:exoscale-dbaas/mysql/create.adoc[Create] and xref:exoscale-dbaas/mysql/usage.adoc[use]
 |
+|
 
 |Redis
 |xref:exoscale-dbaas/redis/create.adoc[Create] and xref:exoscale-dbaas/redis/usage.adoc[use]
+|xref:vshn-managed/redis/create.adoc[Create] and xref:vshn-managed/redis/usage.adoc[use]
 |xref:vshn-managed/redis/create.adoc[Create] and xref:vshn-managed/redis/usage.adoc[use]
 
 |Kafka
 |xref:exoscale-dbaas/kafka/create.adoc[Create] and xref:exoscale-dbaas/kafka/usage.adoc[use]
 |
+|
 
 |OpenSearch
 |xref:exoscale-dbaas/opensearch/create.adoc[Create] and xref:exoscale-dbaas/opensearch/usage.adoc[use]
+|
 |
 
 |Object Storage (S3)
 |xref:object-storage/create.adoc[Create] and xref:object-storage/create.adoc[use]
 |xref:object-storage/create.adoc[Create] and xref:object-storage/create.adoc[use]
+|xref:object-storage/create.adoc[Create] and xref:object-storage/create.adoc[use]
+
+|MinIO
+|xref:vshn-managed/minio.adoc[Create] and xref:object-storage/create.adoc[use]
+|xref:vshn-managed/minio.adoc[Create] and xref:object-storage/create.adoc[use]
+|xref:vshn-managed/minio.adoc[Create] and xref:object-storage/create.adoc[use]
 
 |===
 

--- a/docs/modules/ROOT/pages/vshn-managed/minio.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/minio.adoc
@@ -1,10 +1,6 @@
-= Minio by VSHN
+= MinIO by VSHN
 
-APPUiO Managed clusters will use the underlying cloud's Object Storage to provide Object Storage by default.
-For example: if the APPUiO Managed cluster is running on Exoscale, then AppCat will provide Exoscale's SOS service for `ObjectBuckets`.
-If you're on-premise without any existing Object Storage solution, then Minio will already be installed on the cluster, as it's required for AppCat to work.
-If you have any other use-cases for Minio, please open a ticket or contact us via support@vshn.ch.
-We will then provision Minio according to your specifications on the cluster.
+MinIO by VSHN is currently only available on APPUiO Managed on request.
+Please https://www.vshn.ch/en/contact/[contact^] us to discuss your requirements.
 
-Once Minio is enabled on an APPUiO Managed cluster, please follow xref:object-storage/create.adoc[this page] on how to create an object bucket.
-Please refer to the xref:object-storage/references.adoc[reference documentation] to learn how to select the Minio instances, if multiple instances are available.
+Once MinIO is enabled on your cluster, please follow xref:object-storage/create.adoc[this page] to learn how to create an object storage bucket.

--- a/docs/modules/ROOT/pages/vshn-managed/minio.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/minio.adoc
@@ -1,0 +1,10 @@
+= Minio by VSHN
+
+APPUiO Managed clusters will use the underlying cloud's Object Storage to provide Object Storage by default.
+For example: if the APPUiO Managed cluster is running on Exoscale, then AppCat will provide Exoscale's SOS service for `ObjectBuckets`.
+If you're on-premise without any existing Object Storage solution, then Minio will already be installed on the cluster, as it's required for AppCat to work.
+If you have any other use-cases for Minio, please open a ticket or contact us via support@vshn.ch.
+We will then provision Minio according to your specifications on the cluster.
+
+Once Minio is enabled on an APPUiO Managed cluster, please follow xref:object-storage/create.adoc[this page] on how to create an object bucket.
+Please refer to the xref:object-storage/references.adoc[reference documentation] to learn how to select the Minio instances, if multiple instances are available.


### PR DESCRIPTION
These docs explain how customers can get Minio on their clusters.

Minio is a bit a special case and usually not enabled by default, as the cloud provider's object storage is preferred by default.

Full self-service provision for Minio is unfortunately not that trivial to achieve, as each Minio instance will require a separate composition pointing to that instance and wiring up the credentials to work with the `ObjectBucket` objects.

So to get full self-service for Minio we'd need to engineer a composition which in turn creates new compositions on the fly. While it's doable with composition functions, it's a construct that can pretty easily explode in complexity.

Unless full self-service Minio is something our customers really crave, I'd suggest keeping it as described in the docs and put that effort in other services on the roadmap.