### PR TITLE
Document new deletionProtection feature

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -16,13 +16,13 @@
 ** xref:vshn-managed/postgresql/usage.adoc[Usage]
 ** xref:vshn-managed/postgresql/connect.adoc[Connect]
 ** xref:vshn-managed/postgresql/delete.adoc[Deletion]
+** xref:vshn-managed/postgresql/deletion-protection.adoc[]
 ** xref:vshn-managed/postgresql/backup.adoc[Backup]
 ** xref:vshn-managed/postgresql/restore.adoc[Restore]
 ** xref:vshn-managed/postgresql/security.adoc[Security]
 ** xref:vshn-managed/postgresql/maintenance.adoc[]
 ** xref:vshn-managed/postgresql/plans.adoc[]
 ** xref:vshn-managed/postgresql/sla.adoc[]
-** xref:vshn-managed/postgresql/deletion-protection.adoc[]
 ** xref:vshn-managed/postgresql/encrypted-pvc.adoc[]
 ** xref:vshn-managed/postgresql/alerting.adoc[]
 ** xref:vshn-managed/postgresql/update-strategy.adoc[]
@@ -42,9 +42,11 @@
 ** xref:vshn-managed/mariadb/maintenance.adoc[]
 ** xref:vshn-managed/mariadb/usage.adoc[Usage]
 ** xref:vshn-managed/mariadb/delete.adoc[Deletion]
+** xref:vshn-managed/mariadb/deletion-protection.adoc[]
 ** xref:vshn-managed/mariadb/plans.adoc[]
 ** xref:vshn-managed/mariadb/restore.adoc[Restore]
 ** xref:vshn-managed/mariadb/security.adoc[Security]
+
 
 .Redis
 * xref:exoscale-dbaas/redis/index.adoc[On Exoscale]
@@ -56,10 +58,12 @@
 ** xref:vshn-managed/redis/maintenance.adoc[]
 ** xref:vshn-managed/redis/usage.adoc[Usage]
 ** xref:vshn-managed/redis/delete.adoc[Deletion]
+** xref:vshn-managed/redis/deletion-protection.adoc[]
 ** xref:vshn-managed/redis/plans.adoc[]
 ** xref:vshn-managed/redis/backup.adoc[Backup]
 ** xref:vshn-managed/redis/restore.adoc[Restore]
 ** xref:vshn-managed/redis/security.adoc[Security]
+
 
 .Kafka
 * xref:exoscale-dbaas/kafka/index.adoc[On Exoscale]
@@ -73,11 +77,13 @@
 ** xref:vshn-managed/keycloak/maintenance.adoc[]
 ** xref:vshn-managed/keycloak/usage.adoc[Usage]
 ** xref:vshn-managed/keycloak/delete.adoc[Deletion]
+** xref:vshn-managed/keycloak/deletion-protection.adoc[]
 ** xref:vshn-managed/keycloak/plans.adoc[]
 ** xref:vshn-managed/keycloak/restore.adoc[Restore]
 ** xref:vshn-managed/keycloak/security.adoc[Security]
 ** xref:vshn-managed/keycloak/replicas.adoc[]
 ** xref:vshn-managed/keycloak/customization.adoc[]
+
 
 .Nextcloud
 * xref:vshn-managed/nextcloud/index.adoc[On cloudscale.ch]
@@ -85,7 +91,9 @@
 ** xref:vshn-managed/nextcloud/maintenance.adoc[]
 ** xref:vshn-managed/nextcloud/usage.adoc[Usage]
 ** xref:vshn-managed/nextcloud/delete.adoc[Deletion]
+** xref:vshn-managed/nextcloud/deletion-protection.adoc[]
 ** xref:vshn-managed/nextcloud/plans.adoc[]
+
 
 .OpenSearch
 * xref:exoscale-dbaas/opensearch/index.adoc[On Exoscale]

--- a/docs/modules/ROOT/pages/references/delete.adoc
+++ b/docs/modules/ROOT/pages/references/delete.adoc
@@ -1,0 +1,7 @@
+// tag::common[]
+[IMPORTANT]
+.Non-reversible operation
+====
+If you delete the instance from the cluster, it will be deleted together with all of its data and backups!
+====
+// end::common[]

--- a/docs/modules/ROOT/pages/references/deletion-protection.adoc
+++ b/docs/modules/ROOT/pages/references/deletion-protection.adoc
@@ -1,0 +1,144 @@
+= Instance Deletion Protection
+
+// tag::common[]
+[IMPORTANT]
+====
+The Deletion Protection feature is enabled by default and ensures your instance is not deleted by accident.
+====
+
+== Configuration
+
+Deletion protection can be enabled or disabled using the following configuration:
+// end::common[]
+
+// tag::keycloak[]
+.Example of a Keycloak instance with deletion protection on. Update the namespace!
+[source,yaml]
+----
+apiVersion: vshn.appcat.vshn.io/v1
+kind: VSHNKeycloak
+metadata:
+  name: keycloak-app1-prod
+  namespace: <your-namespace>
+spec:
+  parameters:
+    security:
+      deletionProtection: true # <1>
+    service:
+      version: "23"
+      postgreSQLParameters: {}
+    size:
+      plan: standard-2
+  writeConnectionSecretToRef:
+    name: keycloak-creds
+----
+<1> Enable or disable instance deletion protection.
+// end::keycloak[]
+
+// tag::mariadb[]
+.Example of a MariaDB instance with deletion protection on. Update the namespace!
+[source,yaml]
+----
+apiVersion: vshn.appcat.vshn.io/v1
+kind: VSHNMariaDB
+metadata:
+  name: mariadb-app1-prod
+  namespace: <your-namespace>
+spec:
+  parameters:
+    security:
+      deletionProtection: true # <1>
+    service:
+      version: "11.2"
+    size:
+      plan: standard-2
+  writeConnectionSecretToRef:
+    name: mariadb-creds
+----
+<1> Enable or disable instance deletion protection.
+// end::mariadb[]
+
+// tag::nextcloud[]
+.Example of a Nextcloud instance with deletion protection on. Update the namespace!
+[source,yaml]
+----
+apiVersion: vshn.appcat.vshn.io/v1
+kind: VSHNNextcloud
+metadata:
+  name: nextcloud-app1-prod
+  namespace: <your-namespace>
+spec:
+  parameters:
+    security:
+      deletionProtection: true # <1>
+    service:
+      fqdn: my-nextcloud.example.com
+      version: "29"
+      useExternalPostgreSQL: true
+      postgreSQLParameters: {}
+    size:
+      plan: standard-2
+  writeConnectionSecretToRef:
+    name: nextcloud-creds
+----
+<1> Enable or disable instance deletion protection.
+// end::nextcloud[]
+
+// tag::postgresql[]
+.Example of a PostgreSQL instance with deletion protection on. Update the namespace!
+[source,yaml]
+----
+apiVersion: vshn.appcat.vshn.io/v1
+kind: VSHNPostgreSQL
+metadata:
+  name: pgsql-app1
+  namespace: <your-namespace>
+spec:
+  parameters:
+    security:
+      deletionProtection: true # <1>
+    backup:
+      deletionProtection: true <2>
+      deletionRetention: 10 <2>
+      schedule: '0 22 * * *'
+    service:
+      majorVersion: "15"
+      pgSettings:
+        timezone: Europe/Zurich
+    size:
+      cpu: "600m"
+      memory: "3500Mi"
+      disk: "80Gi"
+  writeConnectionSecretToRef:
+    name: postgres-creds
+----
+<1> Enable or disable instance deletion protection.
+<2> This is now deprecated and doesn't have any effect. Upon deletion of the instance, the backups are deleted as well.
+// end::postgresql[]
+
+// tag::redis[]
+.Example of a Redis instance with deletion protection on. Update the namespace!
+[source,yaml]
+----
+apiVersion: vshn.appcat.vshn.io/v1
+kind: VSHNRedis
+metadata:
+  name: redis-app1
+  namespace: <your-namespace>
+spec:
+  parameters:
+    security:
+      deletionProtection: true # <1>
+    backup:
+      schedule: '0 22 * * *'
+    service:
+      version: "7.0"
+      redisSettings: |
+        activedefrag yes
+    size:
+      plan: standard-2
+  writeConnectionSecretToRef:
+    name: redis-creds
+----
+<1> Enable or disable instance deletion protection.
+// end::redis[]

--- a/docs/modules/ROOT/pages/vshn-managed/keycloak/delete.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/keycloak/delete.adoc
@@ -9,8 +9,43 @@ If you do not need your Keycloak service anymore, you can delete it in the same 
 $ oc delete vshnkeycloak.vshn.appcat.vshn.io keycloak-app1-prod
 ----
 
-[IMPORTANT]
-.Non-reversible operation
+include::page$references/delete.adoc[tag=common]
+
 ====
-If you delete the `VSHNKeycloak` object from the cluster without having xref:vshn-managed/postgresql/deletion-protection.adoc[deletion-protection] enabled, the Keycloak instance will be deleted together with all of its data and backups!
-====
+
+== Delete protected Keycloak instance
+
+A Keycloak instance that is protected from deletion cannot be deleted right away.
+First disable deletion protection then delete the instance.
+
+. Disable deletion protection:
++
+[source,bash]
+----
+$ oc edit vshnkeycloak.vshn.appcat.vshn.io keycloak-app1-prod
+----
++
+[source,yaml]
+----
+apiVersion: vshn.appcat.vshn.io/v1
+kind: VSHNKeycloak
+metadata:
+  name: keycloak-app1-prod
+  namespace: prod-app
+spec:
+  parameters:
+    security:
+      deletionProtection: false # <1>
+  writeConnectionSecretToRef:
+    name: keycloak-creds
+----
+<1> Make sure the parameter is set to false
+
+. Delete the instance
++
+[source,bash]
+----
+$ oc delete vshnkeycloak.vshn.appcat.vshn.io keycloak-app1-prod
+----
++
+include::page$references/delete.adoc[tag=common]

--- a/docs/modules/ROOT/pages/vshn-managed/keycloak/deletion-protection.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/keycloak/deletion-protection.adoc
@@ -1,0 +1,5 @@
+= Deletion Protection
+
+include::page$references/deletion-protection.adoc[tag=common]
+
+include::page$references/deletion-protection.adoc[tag=keycloak]

--- a/docs/modules/ROOT/pages/vshn-managed/mariadb/delete.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/mariadb/delete.adoc
@@ -9,8 +9,41 @@ If you do not need your MariaDB service anymore, you can delete it in the same w
 $ oc delete vshnmariadb.vshn.appcat.vshn.io mariadb-app1-prod
 ----
 
-[IMPORTANT]
-.Non-reversible operation
-====
-If you delete the `VSHNMariaDB` object from the cluster, it will be deleted together with all of its data!
-====
+include::page$references/delete.adoc[tag=common]
+
+== Delete protected MariaDB instance
+
+A MariaDB instance that is protected from deletion cannot be deleted right away.
+First disable deletion protection then delete the instance.
+
+. Disable deletion protection:
++
+[source,bash]
+----
+$ oc edit vshnmariadb.vshn.appcat.vshn.io mariadb-app1-prod
+----
++
+[source,yaml]
+----
+apiVersion: vshn.appcat.vshn.io/v1
+kind: VSHNMariaDB
+metadata:
+  name: mariadb-app1-prod
+  namespace: prod-app
+spec:
+  parameters:
+    security:
+      deletionProtection: false # <1>
+  writeConnectionSecretToRef:
+    name: mariadb-creds
+----
+<1> Make sure the parameter is set to false
+
+. Delete the instance
++
+[source,bash]
+----
+$ oc edit vshnmariadb.vshn.appcat.vshn.io mariadb-app1-prod
+----
++
+include::page$references/delete.adoc[tag=common]

--- a/docs/modules/ROOT/pages/vshn-managed/mariadb/deletion-protection.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/mariadb/deletion-protection.adoc
@@ -1,0 +1,5 @@
+= Deletion Protection
+
+include::page$references/deletion-protection.adoc[tag=common]
+
+include::page$references/deletion-protection.adoc[tag=mariadb]

--- a/docs/modules/ROOT/pages/vshn-managed/nextcloud/delete.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/nextcloud/delete.adoc
@@ -9,8 +9,41 @@ If you do not need your Nextcloud service anymore, you can delete it in the same
 $ oc delete vshnnextcloud.vshn.appcat.vshn.io nextcloud-app1-prod
 ----
 
-[IMPORTANT]
-.Non-reversible operation
-====
-If you delete the `VSHNNextcloud` object from the cluster without having xref:vshn-managed/postgresql/deletion-protection.adoc[deletion-protection] enabled, the Nextcloud instance will be deleted together with all of its data and backups!
-====
+include::page$references/delete.adoc[tag=common]
+
+== Delete protected Nextcloud instance
+
+A Nextcloud instance that is protected from deletion cannot be deleted right away.
+First disable deletion protection then delete the instance.
+
+. Disable deletion protection:
++
+[source,bash]
+----
+$ oc delete vshnnextcloud.vshn.appcat.vshn.io nextcloud-app1-prod
+----
++
+[source,yaml]
+----
+apiVersion: vshn.appcat.vshn.io/v1
+kind: VSHNNextcloud
+metadata:
+  name: nextcloud-app1-prod
+  namespace: prod-app
+spec:
+  parameters:
+    security:
+      deletionProtection: false # <1>
+  writeConnectionSecretToRef:
+    name: nextcloud-creds
+----
+<1> Make sure the parameter is set to false
+
+. Delete the instance
++
+[source,bash]
+----
+$ oc delete vshnnextcloud.vshn.appcat.vshn.io nextcloud-app1-prod
+----
++
+include::page$references/delete.adoc[tag=common]

--- a/docs/modules/ROOT/pages/vshn-managed/nextcloud/deletion-protection.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/nextcloud/deletion-protection.adoc
@@ -1,0 +1,5 @@
+= Deletion Protection
+
+include::page$references/deletion-protection.adoc[tag=common]
+
+include::page$references/deletion-protection.adoc[tag=nextcloud]

--- a/docs/modules/ROOT/pages/vshn-managed/postgresql/delete.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/postgresql/delete.adoc
@@ -6,14 +6,10 @@ If you do not need your PostgreSQL service anymore, you can delete it in the sam
 
 [source,bash]
 ----
-$ oc delete vshnpostgresqls.vshn.appcat.vshn.io my-postgres-example
+$ oc delete vshnpostgresqls.vshn.appcat.vshn.io pgsql-app1-prod
 ----
 
-[IMPORTANT]
-.Non-reversible operation
-====
-If you delete the `VSHNPostgreSQL` object from the cluster, it will be deleted together with all of its data!
-====
+include::page$references/delete.adoc[tag=common]
 
 == Delete protected PostgreSQL instance
 
@@ -24,7 +20,7 @@ First disable deletion protection then delete the instance.
 +
 [source,bash]
 ----
-$ oc edit vshnpostgresqls.vshn.appcat.vshn.io my-postgres-example
+$ oc edit vshnpostgresqls.vshn.appcat.vshn.io pgsql-app1-prod
 ----
 +
 [source,yaml]
@@ -36,7 +32,7 @@ metadata:
   namespace: prod-app
 spec:
   parameters:
-    backup:
+    security:
       deletionProtection: false # <1>
   writeConnectionSecretToRef:
     name: postgres-creds
@@ -47,11 +43,7 @@ spec:
 +
 [source,bash]
 ----
-$ oc delete vshnpostgresqls.vshn.appcat.vshn.io my-postgres-example
+$ oc delete vshnpostgresqls.vshn.appcat.vshn.io pgsql-app1-prod
 ----
 +
-[IMPORTANT]
-.Non-reversible operation
-====
-If you delete the `VSHNPostgreSQL` object from the cluster, it will be deleted together with all of its data!
-====
+include::page$references/delete.adoc[tag=common]

--- a/docs/modules/ROOT/pages/vshn-managed/postgresql/deletion-protection.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/postgresql/deletion-protection.adoc
@@ -1,41 +1,9 @@
 = Database Deletion Protection
 
-[IMPORTANT]
-====
-The Deletion Protection feature is enabled by default and ensures backups are available for 7 days
-after a database instance is deleted. Any backup available at the time of an instance deletion can be used
-to restore data into a new instance. The Deletion Protection feature does not restore the deleted
-database instance.
-====
+[WARNING]
+The backup deletion protection is deprecated and has been replaced by the instance deletion protection.
+If you delete your instance, all backups will be deleted as well.
 
-== Configuration
+include::page$references/deletion-protection.adoc[tag=common]
 
-Deletion protection can be enabled or disabled and the retention period can be defined using the following configuration:
-
-.Example of a PostgreSQL instance with database deletion protection on. Update the namespace!
-[source,yaml]
-----
-apiVersion: vshn.appcat.vshn.io/v1
-kind: VSHNPostgreSQL
-metadata:
-  name: pgsql-app1-restore
-  namespace: <your-namespace>
-spec:
-  parameters:
-    backup:
-      deletionProtection: true <1>
-      deletionRetention: 10 <2>
-      schedule: '0 22 * * *'
-    service:
-      majorVersion: "15"
-      pgSettings:
-        timezone: Europe/Zurich
-    size:
-      cpu: "600m"
-      memory: "3500Mi"
-      disk: "80Gi"
-  writeConnectionSecretToRef:
-    name: postgres-creds
-----
-<1> Enable or disable database deletion protection.
-<2> The number of days the backups should be available after a database is deleted.
+include::page$references/deletion-protection.adoc[tag=postgresql]

--- a/docs/modules/ROOT/pages/vshn-managed/redis/delete.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/redis/delete.adoc
@@ -4,11 +4,44 @@ If you do not need a Redis service anymore, you can delete it in the same way as
 
 [source,bash]
 ----
-$ oc delete vshnredis.vshn.appcat.vshn.io my-redis-example
+$ oc delete vshnredis.vshn.appcat.vshn.io redis-app1-prod
 ----
 
-[IMPORTANT]
-.Non-reversible operation
-====
-If you delete the `VSHNRedis` object from the cluster, it will be deleted together with all of its data!
-====
+include::page$references/delete.adoc[tag=common]
+
+== Delete protected Redis instance
+
+A Redis instance that is protected from deletion cannot be deleted right away.
+First disable deletion protection then delete the instance.
+
+. Disable deletion protection:
++
+[source,bash]
+----
+$ oc delete vshnredis.vshn.appcat.vshn.io redis-app1-prod
+----
++
+[source,yaml]
+----
+apiVersion: vshn.appcat.vshn.io/v1
+kind: VSHNRedis
+metadata:
+  name: redis-app1-prod
+  namespace: prod-app
+spec:
+  parameters:
+    security:
+      deletionProtection: false # <1>
+  writeConnectionSecretToRef:
+    name: redis-creds
+----
+<1> Make sure the parameter is set to false
+
+. Delete the instance
++
+[source,bash]
+----
+$ oc delete vshnredis.vshn.appcat.vshn.io redis-app1-prod
+----
++
+include::page$references/delete.adoc[tag=common]

--- a/docs/modules/ROOT/pages/vshn-managed/redis/deletion-protection.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/redis/deletion-protection.adoc
@@ -1,0 +1,5 @@
+= Deletion Protection
+
+include::page$references/deletion-protection.adoc[tag=common]
+
+include::page$references/deletion-protection.adoc[tag=redis]


### PR DESCRIPTION
This PR documents the new deletionProtection feature that is enabled by default for all instances.
It also documents the changes for the now deprecated deletionProtection for VSHNPostgreSQL