### PR TITLE
Adjust script to use a pod instead of port-forward or exec

### DIFF
--- a/docs/modules/ROOT/examples/migration.sh
+++ b/docs/modules/ROOT/examples/migration.sh
@@ -1,50 +1,41 @@
 #!/usr/bin/env bash
-# pg-migrate.sh — Migrate a VSHNPostgreSQL claim from one cluster to another
-# via kubectl exec + pg_dump | pg_restore (custom format).
+# pg-migrate.sh — Migrate a VSHNPostgreSQL claim to another within the same namespace
+# via a temporary migration pod running pg_dump | pg_restore (custom format).
 #
-# pg_dump and pg_restore run inside the database pods, so no local PostgreSQL
-# installation is required. The postgres superuser connects via Unix socket
-# (peer authentication) — no secrets or passwords are needed.
-#
-# The type of the source instance is detected (StackGres or CNPG) automatically. The destination
-# is always assumed to be CNPG.
+# The migration pod is created in the claim namespace where the connection secrets
+# already live. It streams pg_dump directly into pg_restore inside the cluster,
+# avoiding port-forwarding and making it reliable for large databases.
 #
 # Usage:
 #   ./pg-migrate.sh \
-#     --src-kubeconfig /path/to/src.kubeconfig \
-#     --src-namespace  <claim-namespace> \
-#     --src-claim      <claim-name> \
-#     --dst-kubeconfig /path/to/dst.kubeconfig \   # omit if same cluster
-#     --dst-namespace  <claim-namespace> \
-#     --dst-claim      <claim-name> \
-#     --cleanup-stackgres                          # optional: drop StackGres extensions after restore
-#     --use-port-forward                          # optional: use port-forwarding instead of exec
-#     --as-admin                                  # optional: impersonate system:admin for all kubectl calls
+#     --namespace    <claim-namespace> \
+#     --src-claim    <source-claim-name> \
+#     --dst-claim    <destination-claim-name> \
+#     [--kubeconfig  /path/to/kubeconfig] \
+#     [--image       <postgres-image>]    # default: ghcr.io/cloudnative-pg/postgresql:18
+#     [--cleanup-stackgres]               # optional: drop StackGres extensions after restore
+#     [--as-admin]                        # impersonate system:admin
 
 set -euo pipefail
 
-# ----- Helper functions -----
+# ----- Helpers -----
 
 log() { echo "[$(date +%T)] $*"; }
 die() { echo "[ERROR] $*" >&2; exit 1; }
 
-get_claim_field() {
-  local kubeconfig=$1 namespace=$2 claim=$3 field=$4
-  KUBECONFIG="$kubeconfig" kubectl get vshnpostgresql "$claim" \
-    -n "$namespace" -o jsonpath="{$field}"
-}
+# ----- Helpers StackGres cleanup -----
 
 get_primary_pod() {
-  local kubeconfig=$1 namespace=$2 label_selector=$3
-  KUBECONFIG="$kubeconfig" kubectl get pod \
+  local namespace=$1 label_selector=$2
+  kubectl "${KUBECTL_AS[@]}" get pod \
     -n "$namespace" -l "$label_selector" \
     -o jsonpath='{.items[0].metadata.name}'
 }
 
-cleanup_stackgres() {
-  local kubeconfig=$1 namespace=$2 pod=$3 db=$4
+do_cleanup_stackgres() {
+  local namespace=$1 pod=$2 db=$3
   log "  Removing StackGres extensions and functions from database: $db"
-  KUBECONFIG="$kubeconfig" kubectl "${KUBECTL_AS[@]}" exec -i -n "$namespace" "$pod" -- \
+  kubectl "${KUBECTL_AS[@]}" exec -i -n "$namespace" "$pod" -- \
     psql -U postgres -d "$db" -q <<'EOSQL'
 DO $$
 DECLARE
@@ -66,271 +57,213 @@ DROP EXTENSION IF EXISTS plpython3u;
 EOSQL
 }
 
-exec_restore() {
-  log "Listing databases on source ($SRC_POD)..."
-  DATABASES=$(KUBECONFIG="$SRC_KUBECONFIG" kubectl "${KUBECTL_AS[@]}" exec -n "$SRC_INSTANCE_NS" "$SRC_POD" -- \
-    psql -U postgres -t -A -q -c \
-    "SELECT datname FROM pg_database WHERE datistemplate = false")
-  [[ -n "$DATABASES" ]] || die "No databases found on source"
-  log "  databases: $(echo "$DATABASES" | tr '\n' ' ')"
+# ----- Cleanup -----
 
-  while IFS= read -r db; do
-    [[ -z "$db" ]] && continue
-    log "Migrating database: $db"
-    KUBECONFIG="$SRC_KUBECONFIG" kubectl "${KUBECTL_AS[@]}" exec -n "$SRC_INSTANCE_NS" "$SRC_POD" -- \
-      pg_dump \
-        --username=postgres \
-        --dbname="$db" \
-        --no-password \
-        --format=custom \
-        --compress=0 \
-        --lock-wait-timeout=120s \
-    | KUBECONFIG="$DST_KUBECONFIG" kubectl "${KUBECTL_AS[@]}" exec -i -n "$DST_INSTANCE_NS" "$DST_POD" -- \
-      pg_restore \
-        --username=postgres \
-        --dbname=postgres \
-        --no-password \
-        --clean \
-        --if-exists \
-        --verbose 2>&1 | tee -a "$RESTORE_LOG"
-  done <<< "$DATABASES"
-}
+_MIGRATION_POD=""
 
-wait_for_port() {
-  local port=$1 retries=30
-  while ! nc -z 127.0.0.1 "$port" 2>/dev/null; do
-    ((retries--)) || die "Port $port did not open in time."
-    sleep 1
-  done
-}
-
-read_secret_field() {
-  local kubeconfig=$1 namespace=$2 secret=$3 key=$4
-  KUBECONFIG="$kubeconfig" kubectl "${KUBECTL_AS[@]}" get secret "$secret" \
-    -n "$namespace" -o jsonpath="{.data.$key}" | base64 -d
-}
-
-cleanup() {
-  log "Cleaning up port-forwards..."
-  [[ -n "${SRC_PF_PID:-}" ]] && kill "$SRC_PF_PID" 2>/dev/null || true
-  [[ -n "${DST_PF_PID:-}" ]] && kill "$DST_PF_PID" 2>/dev/null || true
-}
-
-
-port_forward_restore() {
-  trap cleanup EXIT
-  # ----- Get secrets and instance namespaces -----
-
-  log "Resolving source claim ($SRC_NAMESPACE/$SRC_CLAIM)..."
-  SRC_SECRET=$(get_claim_field "$SRC_KUBECONFIG" "$SRC_NAMESPACE" "$SRC_CLAIM" \
-                 '.spec.writeConnectionSecretToRef.name')
-  SRC_INSTANCE_NS=$(get_claim_field "$SRC_KUBECONFIG" "$SRC_NAMESPACE" "$SRC_CLAIM" \
-                 '.status.instanceNamespace')
-  [[ -n "$SRC_SECRET" ]]      || die "Could not read .spec.writeConnectionSecretToRef.name from source claim"
-  [[ -n "$SRC_INSTANCE_NS" ]] || die "Could not read .status.instanceNamespace from source claim"
-
-  log "Resolving destination claim ($DST_NAMESPACE/$DST_CLAIM)..."
-  DST_SECRET=$(get_claim_field "$DST_KUBECONFIG" "$DST_NAMESPACE" "$DST_CLAIM" \
-                 '.spec.writeConnectionSecretToRef.name')
-  DST_INSTANCE_NS=$(get_claim_field "$DST_KUBECONFIG" "$DST_NAMESPACE" "$DST_CLAIM" \
-                 '.status.instanceNamespace')
-  [[ -n "$DST_SECRET" ]]      || die "Could not read .spec.writeConnectionSecretToRef.name from destination claim"
-  [[ -n "$DST_INSTANCE_NS" ]] || die "Could not read .status.instanceNamespace from destination claim"
-
-  # ----- extract credentials from secrets -----
-  # POSTGRESQL_HOST is a cluster-internal FQDN (<svc>.<ns>.svc.cluster.local).
-  # We extract just the service name (first component) for port-forward use.
-
-  log "Reading source credentials from secret '$SRC_SECRET'..."
-  SRC_USER=$(read_secret_field "$SRC_KUBECONFIG" "$SRC_NAMESPACE" "$SRC_SECRET" 'POSTGRESQL_USER')
-  SRC_PASS=$(read_secret_field "$SRC_KUBECONFIG" "$SRC_NAMESPACE" "$SRC_SECRET" 'POSTGRESQL_PASSWORD')
-  SRC_DB=$(read_secret_field   "$SRC_KUBECONFIG" "$SRC_NAMESPACE" "$SRC_SECRET" 'POSTGRESQL_DB')
-  SRC_SVC=$(read_secret_field  "$SRC_KUBECONFIG" "$SRC_NAMESPACE" "$SRC_SECRET" 'POSTGRESQL_HOST' \
-            | cut -d. -f1)
-  SRC_SVC_PORT=$(read_secret_field "$SRC_KUBECONFIG" "$SRC_NAMESPACE" "$SRC_SECRET" 'POSTGRESQL_PORT')
-
-  log "Reading destination credentials from secret '$DST_SECRET'..."
-  DST_USER=$(read_secret_field "$DST_KUBECONFIG" "$DST_NAMESPACE" "$DST_SECRET" 'POSTGRESQL_USER')
-  DST_PASS=$(read_secret_field "$DST_KUBECONFIG" "$DST_NAMESPACE" "$DST_SECRET" 'POSTGRESQL_PASSWORD')
-  DST_DB=$(read_secret_field   "$DST_KUBECONFIG" "$DST_NAMESPACE" "$DST_SECRET" 'POSTGRESQL_DB')
-  DST_SVC=$(read_secret_field  "$DST_KUBECONFIG" "$DST_NAMESPACE" "$DST_SECRET" 'POSTGRESQL_HOST' \
-            | cut -d. -f1)
-  DST_SVC_PORT=$(read_secret_field "$DST_KUBECONFIG" "$DST_NAMESPACE" "$DST_SECRET" 'POSTGRESQL_PORT')
-
-  SRC_LOCAL_PORT=15432
-  DST_LOCAL_PORT=15433
-
-  if [[ "$SRC_STACKGRES" == "true" ]]; then
-    SRC_PF_TARGET="svc/primary-service"
-  else
-    SRC_PF_TARGET="svc/$SRC_SVC"
-  fi
-
-  for p in $SRC_LOCAL_PORT $DST_LOCAL_PORT; do
-    nc -z 127.0.0.1 "$p" 2>/dev/null && die "Local port $p is already in use"
-  done
-
-  log "Port-forwarding source $SRC_PF_TARGET -> 127.0.0.1:$SRC_LOCAL_PORT..."
-  KUBECONFIG="$SRC_KUBECONFIG" kubectl port-forward \
-    -n "$SRC_INSTANCE_NS" "$SRC_PF_TARGET" \
-    "${SRC_LOCAL_PORT}:${SRC_SVC_PORT}" &>/tmp/pf-src.log &
-  SRC_PF_PID=$!
-
-  log "Port-forwarding destination svc/$DST_SVC -> 127.0.0.1:$DST_LOCAL_PORT..."
-  KUBECONFIG="$DST_KUBECONFIG" kubectl port-forward \
-    -n "$DST_INSTANCE_NS" "svc/$DST_SVC" \
-    "${DST_LOCAL_PORT}:${DST_SVC_PORT}" &>/tmp/pf-dst.log &
-  DST_PF_PID=$!
-
-  log "Waiting for port-forwards to be ready..."
-  wait_for_port "$SRC_LOCAL_PORT"
-  wait_for_port "$DST_LOCAL_PORT"
-  log "Port-forwards ready."
-
-  # ----- List source databases -----
-  log "Listing databases on source (via port-forward)..."
-  DATABASES=$(PGPASSWORD="$SRC_PASS" PGSSLMODE=disable psql \
-    --host=127.0.0.1 \
-    --port="$SRC_LOCAL_PORT" \
-    --username="$SRC_USER" \
-    -t -A -q -c \
-    "SELECT datname FROM pg_database WHERE datistemplate = false")
-  [[ -n "$DATABASES" ]] || die "No databases found on source"
-  log "  databases: $(echo "$DATABASES" | tr '\n' ' ')"
-
-  # ----- Dump + Restore -----
-  # sslmode=disable: kubectl port-forward wraps traffic in a plain TCP tunnel;
-  # PostgreSQL's TLS handshake is unreliable through it.
-  # --format=custom: binary format, faster than plain SQL and supports streaming.
-
-  log "Streaming pg_dump | pg_restore..."
-  PGPASSWORD="$SRC_PASS" PGSSLMODE=disable pg_dump \
-    --host=127.0.0.1 \
-    --port="$SRC_LOCAL_PORT" \
-    --username="$SRC_USER" \
-    --dbname="$SRC_DB" \
-    --no-password \
-    --format=custom \
-    --compress=0 \
-    --lock-wait-timeout=120s \
-  | PGPASSWORD="$DST_PASS" PGSSLMODE=disable pg_restore \
-    --host=127.0.0.1 \
-    --port="$DST_LOCAL_PORT" \
-    --username="$DST_USER" \
-    --dbname="$DST_DB" \
-    --no-password \
-    --clean \
-    --if-exists \
-    --single-transaction \
-    --verbose 2>&1 | tee /tmp/pg-restore.log
-
+cleanup_pod() {
+  [[ -z "$_MIGRATION_POD" ]] && return 0
+  log "Cleaning up migration pod '$_MIGRATION_POD'..."
+  kubectl "${KUBECTL_AS[@]}" delete pod "$_MIGRATION_POD" \
+    -n "$NAMESPACE" --ignore-not-found &>/dev/null || true
 }
 
 # ----- Argument parsing -----
 
-SRC_KUBECONFIG=""
-SRC_NAMESPACE=""
+NAMESPACE=""
 SRC_CLAIM=""
-DST_KUBECONFIG=""
-DST_NAMESPACE=""
 DST_CLAIM=""
+IMAGE="ghcr.io/cloudnative-pg/postgresql:18"
 CLEANUP_STACKGRES=false
-USE_PORT_FORWARD=false
 KUBECTL_AS=()
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --src-kubeconfig)    SRC_KUBECONFIG=$2;    shift 2 ;;
-    --src-namespace)     SRC_NAMESPACE=$2;     shift 2 ;;
-    --src-claim)         SRC_CLAIM=$2;         shift 2 ;;
-    --dst-kubeconfig)    DST_KUBECONFIG=$2;    shift 2 ;;
-    --dst-namespace)     DST_NAMESPACE=$2;     shift 2 ;;
-    --dst-claim)         DST_CLAIM=$2;         shift 2 ;;
-    --use-port-forward)  USE_PORT_FORWARD=true; shift ;;
+    --namespace)         NAMESPACE=$2;  shift 2 ;;
+    --src-claim)         SRC_CLAIM=$2;  shift 2 ;;
+    --dst-claim)         DST_CLAIM=$2;  shift 2 ;;
+    --kubeconfig)        export KUBECONFIG=$2; shift 2 ;;
+    --image)             IMAGE=$2;      shift 2 ;;
     --cleanup-stackgres) CLEANUP_STACKGRES=true; shift ;;
     --as-admin)          KUBECTL_AS=(--as system:admin); shift ;;
     *) die "Unknown argument: $1" ;;
   esac
 done
 
-[[ -n "$SRC_KUBECONFIG" ]] || die "--src-kubeconfig is required"
-[[ -n "$SRC_NAMESPACE" ]]  || die "--src-namespace is required"
-[[ -n "$SRC_CLAIM" ]]      || die "--src-claim is required"
-[[ -n "$DST_NAMESPACE" ]]  || die "--dst-namespace is required"
-[[ -n "$DST_CLAIM" ]]      || die "--dst-claim is required"
-
-# If no destination kubeconfig is provided, assume the same cluster
-DST_KUBECONFIG="${DST_KUBECONFIG:-$SRC_KUBECONFIG}"
+[[ -n "$NAMESPACE" ]] || die "--namespace is required"
+[[ -n "$SRC_CLAIM" ]] || die "--src-claim is required"
+[[ -n "$DST_CLAIM" ]] || die "--dst-claim is required"
 
 command -v kubectl &>/dev/null || die "'kubectl' not found in PATH."
 
-# ----- Get instance namespaces -----
+# ----- Resolve connection secrets -----
 
-log "Resolving source claim ($SRC_NAMESPACE/$SRC_CLAIM)..."
-SRC_INSTANCE_NS=$(get_claim_field "$SRC_KUBECONFIG" "$SRC_NAMESPACE" "$SRC_CLAIM" \
-               '.status.instanceNamespace')
-[[ -n "$SRC_INSTANCE_NS" ]] || die "Could not read .status.instanceNamespace from source claim"
+log "Resolving source claim ($NAMESPACE/$SRC_CLAIM)..."
+SRC_SECRET=$(kubectl "${KUBECTL_AS[@]}" get vshnpostgresql "$SRC_CLAIM" \
+  -n "$NAMESPACE" -o jsonpath='{.spec.writeConnectionSecretToRef.name}')
+[[ -n "$SRC_SECRET" ]] || die "Could not read .spec.writeConnectionSecretToRef.name from source claim"
 
-log "Resolving destination claim ($DST_NAMESPACE/$DST_CLAIM)..."
-DST_INSTANCE_NS=$(get_claim_field "$DST_KUBECONFIG" "$DST_NAMESPACE" "$DST_CLAIM" \
-               '.status.instanceNamespace')
-[[ -n "$DST_INSTANCE_NS" ]] || die "Could not read .status.instanceNamespace from destination claim"
+log "Resolving destination claim ($NAMESPACE/$DST_CLAIM)..."
+DST_SECRET=$(kubectl "${KUBECTL_AS[@]}" get vshnpostgresql "$DST_CLAIM" \
+  -n "$NAMESPACE" -o jsonpath='{.spec.writeConnectionSecretToRef.name}')
+[[ -n "$DST_SECRET" ]] || die "Could not read .spec.writeConnectionSecretToRef.name from destination claim"
 
-# ----- Detect source instance type and find primary pods -----
-SRC_STACKGRES=false
+log "  source secret      : $SRC_SECRET"
+log "  destination secret : $DST_SECRET"
 
-log "Detecting source instance type in $SRC_INSTANCE_NS..."
-if KUBECONFIG="$SRC_KUBECONFIG" kubectl get svc primary-service \
-    -n "$SRC_INSTANCE_NS" &>/dev/null; then
-  log "  detected: StackGres -- looking for pod with role=primary"
-  SRC_POD=$(get_primary_pod "$SRC_KUBECONFIG" "$SRC_INSTANCE_NS" "role=primary")
-  SRC_STACKGRES=true
-else
-  log "  detected: CNPG -- looking for pod with cnpg.io/instanceRole=primary"
-  SRC_POD=$(get_primary_pod "$SRC_KUBECONFIG" "$SRC_INSTANCE_NS" "cnpg.io/instanceRole=primary")
-fi
-[[ -n "$SRC_POD" ]] || die "Could not find primary pod in $SRC_INSTANCE_NS"
-log "  source pod: $SRC_POD"
-
-log "Finding destination primary pod in $DST_INSTANCE_NS..."
-DST_POD=$(get_primary_pod "$DST_KUBECONFIG" "$DST_INSTANCE_NS" "cnpg.io/instanceRole=primary")
-[[ -n "$DST_POD" ]] || die "Could not find primary pod in $DST_INSTANCE_NS"
-log "  destination pod: $DST_POD"
-
-log "  source      : postgres@$SRC_POD  (instance ns: $SRC_INSTANCE_NS)"
-log "  destination : postgres@$DST_POD  (instance ns: $DST_INSTANCE_NS)"
-
-# ----- Dump + Restore -----
-# pg_dump runs inside the source pod and streams via kubectl exec to pg_restore
-# in the destination pod.
+# ----- Create migration pod -----
 
 RESTORE_LOG=/tmp/pg-restore.log
 > "$RESTORE_LOG"
 
-if [[ "$USE_PORT_FORWARD" == "true" ]]; then
-  port_forward_restore
+MIGRATION_POD="pg-migration-$(date +%s)"
+_MIGRATION_POD="$MIGRATION_POD"
+trap cleanup_pod EXIT
+
+log "Creating migration pod '$MIGRATION_POD' (image: $IMAGE)..."
+# The inline shell script uses envFrom-injected variables with prefixes:
+#   SRC_POSTGRESQL_{HOST,PORT,USER,PASSWORD,DB}  (from source connection secret)
+#   DST_POSTGRESQL_{HOST,PORT,USER,PASSWORD,DB}  (from destination connection secret)
+# All $-signs are escaped (\$) so bash does not expand them during heredoc
+# processing; they reach the pod shell as literal $.
+kubectl "${KUBECTL_AS[@]}" apply -f - <<EOYAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${MIGRATION_POD}
+  namespace: ${NAMESPACE}
+  labels:
+    app: pg-migration
+spec:
+  restartPolicy: Never
+  containers:
+  - name: migrate
+    image: ${IMAGE}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    command:
+    - /bin/bash
+    - -c
+    - |
+      set -euo pipefail
+      echo "[INFO] Listing source databases..."
+      DATABASES=\$(PGPASSWORD="\${SRC_POSTGRESQL_PASSWORD}" psql \\
+        --host="\${SRC_POSTGRESQL_HOST}" \\
+        --port="\${SRC_POSTGRESQL_PORT}" \\
+        --username="\${SRC_POSTGRESQL_USER}" \\
+        -t -A -q -c "SELECT datname FROM pg_database WHERE datistemplate = false")
+      [ -n "\$DATABASES" ] || { echo "[ERROR] No databases found on source"; exit 1; }
+      echo "[INFO] Databases: \$(echo "\$DATABASES" | tr '\\n' ' ')"
+      for db in \$DATABASES; do
+        echo "[INFO] Migrating database: \$db"
+        PGPASSWORD="\${SRC_POSTGRESQL_PASSWORD}" pg_dump \\
+          --host="\${SRC_POSTGRESQL_HOST}" \\
+          --port="\${SRC_POSTGRESQL_PORT}" \\
+          --username="\${SRC_POSTGRESQL_USER}" \\
+          --dbname="\$db" \\
+          --no-password \\
+          --format=custom \\
+          --compress=0 \\
+          --lock-wait-timeout=120s \\
+        | PGPASSWORD="\${DST_POSTGRESQL_PASSWORD}" pg_restore \\
+          --host="\${DST_POSTGRESQL_HOST}" \\
+          --port="\${DST_POSTGRESQL_PORT}" \\
+          --username="\${DST_POSTGRESQL_USER}" \\
+          --dbname="\${DST_POSTGRESQL_DB}" \\
+          --no-password \\
+          --clean \\
+          --if-exists \\
+          --verbose
+      done
+      echo "[INFO] Migration complete."
+    envFrom:
+    - secretRef:
+        name: ${SRC_SECRET}
+      prefix: SRC_
+    - secretRef:
+        name: ${DST_SECRET}
+      prefix: DST_
+EOYAML
+
+log "Waiting for migration pod to start (up to 120s)..."
+for i in $(seq 1 24); do
+  PHASE=$(kubectl "${KUBECTL_AS[@]}" get pod "$MIGRATION_POD" -n "$NAMESPACE" \
+    -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  case "$PHASE" in
+    Running|Succeeded|Failed) break ;;
+  esac
+  [[ $i -eq 24 ]] && die "Migration pod did not start within 120s (phase: ${PHASE:-unknown})"
+  log "  phase: ${PHASE:-unknown} — waiting..."
+  sleep 5
+done
+
+log "Streaming migration pod logs..."
+kubectl "${KUBECTL_AS[@]}" logs -f "$MIGRATION_POD" \
+  -n "$NAMESPACE" | tee "$RESTORE_LOG" || true
+
+# ----- Check result -----
+
+log "Waiting for migration pod to reach terminal state..."
+for i in $(seq 1 60); do
+  POD_PHASE=$(kubectl "${KUBECTL_AS[@]}" get pod "$MIGRATION_POD" -n "$NAMESPACE" \
+    -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  case "$POD_PHASE" in
+    Succeeded|Failed) break ;;
+  esac
+  [[ $i -eq 60 ]] && die "Migration pod did not finish within 5m after log stream ended (phase: ${POD_PHASE:-unknown})"
+  sleep 5
+done
+
+[[ "$POD_PHASE" == "Succeeded" ]] || die "Migration pod did not succeed (phase: $POD_PHASE) — check logs above"
+
+log "Checking for errors..."
+# pg_restore emits "error:" lines for pre-existing missing objects even with
+# --if-exists. We therefore filter those out.
+if grep -E '^pg_restore: error:' "$RESTORE_LOG" \
+   | grep -qv 'does not exist'; then
+  log "WARNING: errors detected — review $RESTORE_LOG"
 else
-  exec_restore
+  log "Restore finished successfully."
 fi
 
-
 if [[ "$CLEANUP_STACKGRES" == "true" ]]; then
-  log "Cleaning up StackGres extensions and functions on destination..."
+  log "Resolving destination instance namespace..."
+  DST_INSTANCE_NS=$(kubectl "${KUBECTL_AS[@]}" get vshnpostgresql "$DST_CLAIM" \
+    -n "$NAMESPACE" -o jsonpath='{.status.instanceNamespace}')
+  [[ -n "$DST_INSTANCE_NS" ]] || die "Could not read .status.instanceNamespace from destination claim"
+
+  log "Finding destination primary pod in $DST_INSTANCE_NS..."
+  DST_POD=$(get_primary_pod "$DST_INSTANCE_NS" "cnpg.io/instanceRole=primary")
+  [[ -n "$DST_POD" ]] || die "Could not find primary pod in $DST_INSTANCE_NS"
+  log "  destination pod: $DST_POD"
+
+  log "Listing databases on destination..."
+  DATABASES=$(kubectl "${KUBECTL_AS[@]}" exec -n "$DST_INSTANCE_NS" "$DST_POD" -- \
+    psql -U postgres -t -A -q -c \
+    "SELECT datname FROM pg_database WHERE datistemplate = false")
+  [[ -n "$DATABASES" ]] || die "No databases found on destination"
+
+  log "Cleaning up StackGres extensions on destination..."
   while IFS= read -r db; do
     [[ -z "$db" ]] && continue
-    cleanup_stackgres "$DST_KUBECONFIG" "$DST_INSTANCE_NS" "$DST_POD" "$db"
+    do_cleanup_stackgres "$DST_INSTANCE_NS" "$DST_POD" "$db"
   done <<< "$DATABASES"
 
-  log "Removing plpython3u from destination claim ($DST_NAMESPACE/$DST_CLAIM)..."
-  # grep -n returns 1-based line numbers; JSON patch paths are 0-based.
-  PLPYTHON3U_LINE=$(KUBECONFIG="$DST_KUBECONFIG" kubectl get vshnpostgresql "$DST_CLAIM" \
-    -n "$DST_NAMESPACE" \
+  log "Removing plpython3u from destination claim ($NAMESPACE/$DST_CLAIM)..."
+  PLPYTHON3U_LINE=$(kubectl "${KUBECTL_AS[@]}" get vshnpostgresql "$DST_CLAIM" \
+    -n "$NAMESPACE" \
     -o jsonpath='{range .spec.parameters.service.extensions[*]}{.name}{"\n"}{end}' \
     | grep -n 'plpython3u' | cut -d: -f1)
   if [[ -n "$PLPYTHON3U_LINE" ]]; then
     PLPYTHON3U_INDEX=$(( PLPYTHON3U_LINE - 1 ))
-    KUBECONFIG="$DST_KUBECONFIG" kubectl "${KUBECTL_AS[@]}" patch vshnpostgresql "$DST_CLAIM" \
-      -n "$DST_NAMESPACE" \
+    kubectl "${KUBECTL_AS[@]}" patch vshnpostgresql "$DST_CLAIM" \
+      -n "$NAMESPACE" \
       --type=json \
       -p="[{\"op\": \"remove\", \"path\": \"/spec/parameters/service/extensions/$PLPYTHON3U_INDEX\"}]"
     log "  Done."
@@ -339,14 +272,4 @@ if [[ "$CLEANUP_STACKGRES" == "true" ]]; then
   fi
 fi
 
-log "Checking for errors..."
-# pg_restore emits "error:" lines for pre-existing missing objects even with
-# `--if-exists`. We therefore filter those errors out.
-if grep -E '^pg_restore: error:' "$RESTORE_LOG" \
-   | grep -qv 'does not exist'; then
-  log "WARNING: errors detected -- review $RESTORE_LOG"
-else
-  log "Restore finished successfully."
-fi
-
-log "Done: $SRC_NAMESPACE/$SRC_CLAIM -> $DST_NAMESPACE/$DST_CLAIM"
+log "Done: $NAMESPACE/$SRC_CLAIM -> $NAMESPACE/$DST_CLAIM"

--- a/docs/modules/ROOT/pages/vshn-managed/postgresql/migration.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/postgresql/migration.adoc
@@ -2,20 +2,11 @@
 
 == Overview
 
-This guide explains how to migrate from one VSHNPostgreSQL instance to another.
+This guide explains how to migrate from one VSHNPostgreSQL instance to another within the same namespace and cluster.
 
-The script supports two different methods for the migration:
-
- - Using `pg_dump` and `pg_restore` via `kubectl exec` directly inside the database pods.
- This method only works if the kubernetes user has `exec` permissions on both instances.
- If possible, this method should be preffered, as it skips additional network complexities introduced by `port-forward`.
- - Using port-forwarding and locally installed `pg_dump` and `pg_restore` tools.
- This method works with default AppCat namespace permissions. This method requires `pg_dump`, `pg_restore` and `netcat` to be installed on the workstation running the script.
-
-Both approaches supports migrations between instances on different clusters as well as within the same cluster.
-
-The script detects the PostgreSQL type of the source instance (StackGres or CNPG) automatically.
-The destination is always assumed to be a CNPG-based instance.
+The script creates a temporary migration pod in the claim namespace.
+The pod mounts the connection secrets from both claims and streams `pg_dump` directly into `pg_restore` inside the cluster, without any port-forwarding.
+This makes it reliable for large databases.
 
 [WARNING]
 ====
@@ -27,15 +18,12 @@ after the script ran.
 
 == Prerequisites
 
-Ensure the following tools are installed and available in your `PATH`:
-
-* `kubectl` and the required `kubeconfig` for the source (and optionally for the destination cluster).
-
-Both VSHNPostgreSQL claims (source and destination) must already exist and be in a ready state before running the script.
-
+* `kubectl` with a valid kubeconfig for the cluster.
+* Both VSHNPostgreSQL claims (source and destination) must already exist and be in a ready state.
+* Both claims must be in the **same namespace** on the **same cluster**.
 * The destination instance must run PostgreSQL **18** or later.
-* All other extensions used in the source instance must also be present in the destination instance if they are not
-already build-in (see https://docs.appcat.ch/vshn-managed/postgresql/extensions.html#_built_in_extensions[PostgreSQL Extensions]).
+* All extensions used in the source instance must also be present in the destination instance if they are not
+already built-in (see https://docs.appcat.ch/vshn-managed/postgresql/extensions.html#_built_in_extensions[PostgreSQL Extensions]).
 
 === Migrating from a StackGres instance
 
@@ -86,26 +74,21 @@ include::example$migration.sh[]
 chmod +x pg-migrate.sh
 
 ./pg-migrate.sh \
-  --src-kubeconfig /path/to/src.kubeconfig \ <1>
-  --src-namespace  <source-claim-namespace> \ <2>
-  --src-claim      <source-claim-name> \ <3>
-  --dst-kubeconfig /path/to/dst.kubeconfig \ <4>
-  --dst-namespace  <destination-claim-namespace> \ <5>
-  --dst-claim      <destination-claim-name> \ <6>
-  --cleanup-stackgres \ <7>
-  --use-port-forward <8>
-  --as-admin <9>
+  --namespace  <claim-namespace> \ <1>
+  --src-claim  <source-claim-name> \ <2>
+  --dst-claim  <destination-claim-name> \ <3>
+  --kubeconfig /path/to/kubeconfig \ <4>
+  --image      ghcr.io/cloudnative-pg/postgresql:18 \ <5>
+  --cleanup-stackgres \ <6>
+  --as-admin <7>
 ----
-<1> Path to the kubeconfig for the source cluster.
-<2> Namespace of the source VSHNPostgreSQL claim.
-<3> Name of the source VSHNPostgreSQL claim.
-<4> (Optional) Path to the kubeconfig for the destination cluster.
-<5> Namespace of the destination VSHNPostgreSQL claim.
-<6> Name of the destination VSHNPostgreSQL claim.
-<7> (Optional) Drop all `plpython3u`-dependent functions and the extension from every restored database, and remove `plpython3u` from the destination claim's extension list. This will need exec permissions on the target instance.
-<8> (Optional) Use port-fordward to do the migration. Required if the kubernetes user does not have `exec` permissions on both namespaces. If portforward is required, then `--cleanup-stackgres` must be omitted as well.
-<9> (Optional) Use `--as system:admin` to fetch the secrets, patch the claim (if `--cleanup-stackgres` is set) and exec into the pods
-
+<1> Namespace of both VSHNPostgreSQL claims.
+<2> Name of the source VSHNPostgreSQL claim.
+<3> Name of the destination VSHNPostgreSQL claim.
+<4> (Optional) Path to the kubeconfig. Defaults to the `KUBECONFIG` environment variable or `~/.kube/config`.
+<5> (Optional) Container image used for the migration pod. Must be allowed by the cluster image policy. Defaults to `ghcr.io/cloudnative-pg/postgresql:18`.
+<6> (Optional) Drop all `plpython3u`-dependent functions and the extension from every restored database, then remove `plpython3u` from the destination claim's extension list. Requires `exec` permissions on the destination instance namespace.
+<7> (Optional) Use `--as system:admin` for all `kubectl` calls.
 
 . Verify the migration by connecting to the destination instance and checking that the expected data is present.
 +
@@ -116,7 +99,7 @@ claim and remove or deprovision the source instance if it is no longer needed.
 
 [NOTE]
 ====
-The script writes `pg_restore` output to `/tmp/pg-restore.log` on the machine running the script.
+The script writes `pg_restore` output to `/tmp/pg-restore.log` on the local machine.
 Review this file if the script reports warnings at the end.
 Errors about objects that "do not exist" are expected and harmless when `--if-exists` is used.
 ====
@@ -128,12 +111,10 @@ Errors about objects that "do not exist" are expected and harmless when `--if-ex
 [NOTE]
 ====
 `plpython3u` is used for StackGres internal functionality.
-However, if your database uses the `plpython3u` extension these steps can be skipped.
+If your database intentionally uses the `plpython3u` extension, these steps can be skipped.
 ====
 
-If `--cleanup-stackgres` can't be used, you need to do these steps manually.
-
-After the migration is complete, you can remove the `plpython3u` extension from the destination instance if it is no longer needed.
+After migrating from a StackGres instance, remove the `plpython3u` extension from the destination instance if it is no longer needed.
 PostgreSQL requires that all functions depending on the extension are dropped before the extension itself can be removed.
 
 . Connect to the destination instance and identify all functions that use `plpython3u`:


### PR DESCRIPTION
Both option are fragil and require a stable connection. Using a pod, resolves those issues and provides a safer and cleaner migration