### PR TITLE
Update vshnkeycloak docs for 26.7.0

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -30,6 +30,7 @@
 ** xref:vshn-managed/how-tos/custom-image-keycloak.adoc[]
 * xref:vshn-managed/keycloak/delete.adoc[Deletion]
 * xref:vshn-managed/keycloak/deletion-protection.adoc[]
+* xref:vshn-managed/keycloak/log-levels.adoc[]
 * xref:vshn-managed/keycloak/maintenance.adoc[]
 * xref:vshn-managed/keycloak/plans.adoc[]
 * xref:vshn-managed/keycloak/replicas.adoc[]
@@ -131,6 +132,7 @@
 ** xref:exoscale-dbaas/redis/usage.adoc[Usage]
 
 .Changelog
+* xref:changelog/2026-08-04.adoc[2026-08-04]
 * xref:changelog/2026-06-02.adoc[2026-06-02]
 * xref:changelog/2026-05-19.adoc[2026-05-19]
 * xref:changelog/2026-05-05.adoc[2026-05-05]

--- a/docs/modules/ROOT/pages/changelog/2026-08-04.adoc
+++ b/docs/modules/ROOT/pages/changelog/2026-08-04.adoc
@@ -1,0 +1,29 @@
+= Changelog 2026-08-04
+
+This release brings Keycloak 26.7.0, with a change to the user self-registration flow and a new way to change log levels without restarting your instance.
+
+== Keycloak 26.7.0
+
+Your Keycloak instances are updated to 26.7.0 during the next xref:vshn-managed/keycloak/maintenance.adoc[scheduled maintenance].
+If you run a xref:vshn-managed/keycloak/customization.adoc[custom image], you are in charge of the upgrade yourself: rebuild your image on 26.7.0 and update the image tag in your claim.
+
+== User self-registration asks for the password later
+
+If your realm has both user self-registration and email verification enabled, users no longer set their password on the registration form.
+They set it after their email address has been verified. This is a security improvement.
+Realms without self-registration are not affected.
+
+The change is applied to your realms during the upgrade, so you do not have to do anything to get it.
+
+Two things to check if this applies to you:
+
+* If the configuration you supply pins the priorities of the *Verify Email*, *Update Password* or *Configure OTP* required actions, your realm keeps the old behavior. Remove them to get the new flow.
+* If you ship a custom login theme that overrides the registration templates, check it against the new flow.
+
+Details are documented under xref:vshn-managed/keycloak/customization.adoc#_user_self_registration_and_required_actions[User self-registration and required actions].
+
+== Change Keycloak log levels without a restart
+
+Keycloak instances now include an extension that lets you change log levels at runtime, so debugging no longer requires a pod restart.
+You can use it through the admin console of the `master` realm or through its endpoints.
+See xref:vshn-managed/keycloak/log-levels.adoc[Changing log levels at runtime].

--- a/docs/modules/ROOT/pages/vshn-managed/how-tos/custom-image-keycloak.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/how-tos/custom-image-keycloak.adoc
@@ -27,7 +27,7 @@ Answer the prompts:
 ----
 project_name [My Custom Keycloak]: Acme Keycloak
 project_slug [acme-keycloak]:
-keycloak_version [26.6.1]: 26.6.1
+keycloak_version [26.7.0]: 26.7.0
 ----
 +
 This creates a directory named after your `project_slug`.
@@ -41,6 +41,13 @@ cp my-provider.jar acme-keycloak/extensions/
 ----
 +
 Themes go under `themes/` and provider JARs go under `extensions/`.
++
+[WARNING]
+====
+Keycloak 26.7.0 changed the user self-registration flow: the password is no longer collected on the registration form, but on a separate page after the email address has been verified.
+If your login theme overrides the registration templates, check it against the new flow before rolling out the image.
+See xref:vshn-managed/keycloak/customization.adoc#_user_self_registration_and_required_actions[User self-registration and required actions].
+====
 
 . Build the image locally to verify it compiles correctly.
 +
@@ -57,7 +64,7 @@ make build
 make push IMAGE=ghcr.io/my-org/acme-keycloak
 ----
 +
-The image is tagged with the Keycloak version by default (e.g. `26.6.1`).
+The image is tagged with the Keycloak version by default (for example `26.7.0`).
 Override with `TAG=<your-tag>` if needed.
 
 . Reference the image in your `VSHNKeycloak` claim using the `customImage` field.

--- a/docs/modules/ROOT/pages/vshn-managed/keycloak/customization.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/keycloak/customization.adoc
@@ -28,7 +28,7 @@ spec:
     service:
       version: "26"
       customImage:
-        image: ghcr.io/my-org/my-keycloak:26.6.1 # <1>
+        image: ghcr.io/my-org/my-keycloak:26.7.0 # <1>
         imagePullSecretRef:
           name: ghcr-secret # <2>
     size:
@@ -156,6 +156,33 @@ spec:
 ----
 <1> The name of the `ConfigMap`. Must be in the same namespace as the Keycloak claim.
 
+=== User self-registration and required actions
+
+This section only concerns you if your realm has *both* user self-registration and email verification enabled.
+If it does not, nothing changes for you.
+
+As of Keycloak 26.7.0, such a realm no longer asks for the password on the registration form.
+Instead, the password is set after the email address has been verified.
+Keycloak achieves this by moving the *Configure OTP* and *Update Password* required actions after *Verify Email*, and it reorders them automatically when the server is updated.
+
+See the https://www.keycloak.org/docs/26.7.0/upgrading/#verify-email-required-before-credentials-setup-during-user-self-registration[Keycloak upgrading guide^] for the upstream description.
+
+The reordering is applied to your instance during the upgrade, so in a default setup you get the new flow without doing anything.
+
+[WARNING]
+====
+Realm configuration that pins the priorities of *Verify Email*, *Update Password* or *Configure OTP* takes precedence over the reordering.
+If you set those priorities in the configuration you supply through `customConfigurationRef`, your realm keeps the old behavior after the upgrade.
+Remove them to get the new flow, or set them yourself so that *Verify Email* comes first.
+====
+
+Two further points to be aware of:
+
+* *Theming*: the password input fields are removed from the registration form and a new page is added, so custom login themes that override the registration templates may need to be adapted.
+See xref:vshn-managed/how-tos/custom-image-keycloak.adoc[How to create a custom Keycloak container image].
+* *Reverting*: the *Password validation* authenticator in the registration flow has an *Always set password on register form* option that restores the previous behavior.
+It is deprecated and expected to be removed in a future Keycloak release, so use it only to buy time for adapting your theme and configuration.
+
 == Environment variables
 
 You can pass custom environment variables to your Keycloak instance. These variables can be used by your custom providers or custom configuration.
@@ -276,7 +303,7 @@ Mount names must be unique within the customMounts list to avoid folder name col
 
 == Propagating Changes to Referenced Resources
 
-When you make changes to a `ConfigMap` or `Secret` that is referenced by your `VSHNKeycloak` instance (e.g., via `customConfigurationRef`, `customEnvVariablesRef` or `customMounts`), these changes are not immediately propagated to the running Keycloak instance.
+When you make changes to a `ConfigMap` or `Secret` that is referenced by your `VSHNKeycloak` instance (for example via `customConfigurationRef`, `customEnvVariablesRef` or `customMounts`), these changes are not immediately propagated to the running Keycloak instance.
 
 To force a reconciliation and apply the updated configuration or environment variables, you need to annotate the `VSHNKeycloak` resource. This tells Crossplane to re-evaluate the resource and apply any changes from its external references.
 
@@ -285,4 +312,4 @@ To force a reconciliation and apply the updated configuration or environment var
 ----
 kubectl annotate vshnkeycloak [NAME] -n [NAMESPACE] crossplane.io/touch="$(date +%s)" --overwrite
 ----
-Replace `[NAME]` with the name of your `VSHNKeycloak` instance (e.g., `keycloak-app1-prod` or `keycloak-app2-prod`), and `[NAMESPACE]` with the namespace where the claim was created.
+Replace `[NAME]` with the name of your `VSHNKeycloak` instance (for example `keycloak-app1-prod` or `keycloak-app2-prod`), and `[NAMESPACE]` with the namespace where the claim was created.

--- a/docs/modules/ROOT/pages/vshn-managed/keycloak/log-levels.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/keycloak/log-levels.adoc
@@ -1,0 +1,35 @@
+= Log levels
+
+As of Keycloak 26.7.0, your instance ships with the https://github.com/keycloak-competence-center/keycloak-log-level/blob/main/extensions/keycloak-log-level/README.md[Keycloak Dynamic Log Level extension^].
+It lets you raise or lower log levels while the instance is running, so debugging no longer requires a pod restart.
+
+NOTE: For reading the logs themselves, see xref:vshn-managed/how-tos/logging.adoc[How-To Access Service Logs].
+
+In short:
+
+* Log levels are managed on the `master` realm only, because the logger configuration is JVM-global.
+* You can change them through a REST endpoint under `/realms/master/logging`, or through a *Log levels* entry in the admin console sidebar.
+* Both require a user with the `admin` role in the `master` realm.
+* The admin console entry only appears once the admin theme `keycloak-log-level` is selected on the `master` realm *and* a public OIDC client named `keycloak-log-level-ui` exists. Without the client, only the REST endpoint is available.
+
+The upstream README documents the endpoint operations, the accepted log levels, the OIDC client definition and how to customize or translate the UI.
+The rest of this page covers what is specific to running Keycloak on AppCat.
+
+== Changes are temporary
+
+Log level changes are not persisted. They live in memory and are lost when a pod restarts, for example during xref:vshn-managed/keycloak/maintenance.adoc[scheduled maintenance].
+Use them for short-lived diagnostics, and note that a change is broadcast to the other replicas of your instance if you run xref:vshn-managed/keycloak/replicas.adoc[more than one].
+
+For a log level that has to survive restarts, set `KC_LOG_LEVEL` through xref:vshn-managed/keycloak/customization.adoc#_environment_variables[environment variables] instead.
+
+== Redirect URIs when using `relativePath`
+
+If you set `spec.parameters.service.relativePath` on your instance, the redirect URIs of the `keycloak-log-level-ui` client must include that prefix.
+Keycloak resolves a redirect URI pattern against the host, not against the realm frontend URL, so the prefix is not applied automatically.
+
+For example, with `relativePath: /auth/`, use `/auth/resources/*` instead of `/resources/*`.
+
+== Custom images
+
+Images built from the https://github.com/vshn/custom-keycloak-image-template[custom-keycloak-image-template^] are based on the same Keycloak image and re-run `kc.sh build`, so the extension is included there as well.
+See xref:vshn-managed/how-tos/custom-image-keycloak.adoc[How to create a custom Keycloak container image].


### PR DESCRIPTION
This PR updated the documentation regarding the changes in Keycloak 26.7.0.
* Change in self user registration
* Possibility of changing log levels at runtime